### PR TITLE
[FIX] RCE using "execFile()" instead of "exec()"

### DIFF
--- a/src/lib/gpio.js
+++ b/src/lib/gpio.js
@@ -44,7 +44,7 @@ var GPIO = function(pinNumber, direction) {
 	_self.direction = direction;
 	currentValue = -1;
 
-	proc.execFile(gpio ['mode', pinNumber, direction], function(error, stdout, stderr) {
+	proc.execFile(gpio, ['mode', pinNumber, direction], function(error, stdout, stderr) {
 		if (error) throw new Error(stderr);
 		_self.emit(gpioEventNames.ready);
 		if (_self.direction === 'in') {

--- a/src/lib/gpio.js
+++ b/src/lib/gpio.js
@@ -44,7 +44,7 @@ var GPIO = function(pinNumber, direction) {
 	_self.direction = direction;
 	currentValue = -1;
 
-	proc.exec([gpio, 'mode', pinNumber, direction].join(' '), function(error, stdout, stderr) {
+	proc.execFile(gpio ['mode', pinNumber, direction], function(error, stdout, stderr) {
 		if (error) throw new Error(stderr);
 		_self.emit(gpioEventNames.ready);
 		if (_self.direction === 'in') {
@@ -75,7 +75,7 @@ util.inherits(GPIO, EventEmitter);
  */
 GPIO.prototype.write = function(value, callback) {
 	if (this.direction !== 'out') throw new Error('The pin is not configured in "out" mode');
-	proc.exec([gpio, 'write', this.pinNumber, value].join(' '), function(error, stdout, stderr) {
+	proc.execFile(gpio, ['write', this.pinNumber, value], function(error, stdout, stderr) {
 		if (error) throw new Error(stderr);
 		if (typeof callback === 'function') callback();
 	});
@@ -103,7 +103,7 @@ GPIO.prototype.low = function(callback) {
  * @throws {Error} - an Error if the read went wrong
  */
 GPIO.prototype.read = function(callback) {
-	proc.exec([gpio, 'read', this.pinNumber].join(' '), function(error, stdout, stderr) {
+	proc.execFile(gpio, ['read', this.pinNumber], function(error, stdout, stderr) {
 		if (error) throw new Error(stderr);
 		if (typeof callback === 'function' && typeof stdout === 'string') callback(stdout.trim());
 	});

--- a/src/lib/gpio.js
+++ b/src/lib/gpio.js
@@ -40,6 +40,11 @@ var gpioEventNames = {
  */
 var GPIO = function(pinNumber, direction) {
 	var _self = this;
+	if (!isNaN(pinNumber))
+		pinNumber = Number(pinNumber)
+	else
+		throw new Error("The pin is invalid: not a number")
+	
 	_self.pinNumber = pinNumber;
 	_self.direction = direction;
 	currentValue = -1;
@@ -74,6 +79,7 @@ util.inherits(GPIO, EventEmitter);
  * @throws {Error} - an Error if the write went wrong
  */
 GPIO.prototype.write = function(value, callback) {
+	if (isNaN(this.pinNumber)) throw new Error('The pin is invalid: not a number')
 	if (this.direction !== 'out') throw new Error('The pin is not configured in "out" mode');
 	proc.execFile(gpio, ['write', this.pinNumber, value], function(error, stdout, stderr) {
 		if (error) throw new Error(stderr);
@@ -103,6 +109,7 @@ GPIO.prototype.low = function(callback) {
  * @throws {Error} - an Error if the read went wrong
  */
 GPIO.prototype.read = function(callback) {
+	if (isNaN(this.pinNumber)) throw new Error('The pin is invalid: not a number')
 	proc.execFile(gpio, ['read', this.pinNumber], function(error, stdout, stderr) {
 		if (error) throw new Error(stderr);
 		if (typeof callback === 'function' && typeof stdout === 'string') callback(stdout.trim());


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-rpi

### ⚙️ Description *

The `ri` library was vulnerable against `RCE` and `arbitrary command injection` cause some `user supplied` inputs were taken and formatted inside the `exec()` function without prior validation.

### 💻 Technical Description *

I used the `execFile()` function instead of `exec()` and the inputs provided as `parameters`, making impossible exploit again the issue.

### 🐛 Proof of Concept (PoC) *

1. Download the library
2. Create in the new dir the following PoC:

```js
// poc.js
var RPI = require("./");
var pin = new RPI.GPIO(';touch vulnerable.txt;', '123');
```

3. `node poc.js`
4. The `vulnerable.txt` file is created 

![Screenshot from 2020-09-01 12-29-59](https://user-images.githubusercontent.com/33063403/91839815-f8440400-ec4f-11ea-80ef-51f88c118930.png)

### 🔥 Proof of Fix (PoF) *

Same steps with the fixed version 

![Screenshot from 2020-09-01 12-33-48](https://user-images.githubusercontent.com/33063403/91839829-0003a880-ec50-11ea-841e-42894dc3c7bf.png)

(note in the `screen` is present an `error` ... it's thrown since my machine doesn't have a command called `gpio` :smile:)

### 👍 User Acceptance Testing (UAT)

All good :+1: 